### PR TITLE
Update block index name

### DIFF
--- a/db.js
+++ b/db.js
@@ -63,7 +63,7 @@ var block = {
   replace: async function(items, block_index) {
     console.log('Deleting all blocks greater than or equal to', block_index)
     await db.collection('confirmed').deleteMany({
-      block_index: {
+      'blk.i': {
         $gte: block_index
       }
     }).catch(function(err) {


### PR DESCRIPTION
This might be the reason my blocks weren't deleting.

However, I was unable to test that this resolved the issue as the mongo call would time out even after increasing timeout to 5 minutes. This was with trying to delete 17k blocks.