### PR TITLE
Updated bigjq dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bcode": "0.0.6",
-    "bigjq": "0.0.7",
+    "bigjq": "0.0.15",
     "bitcoind-rpc": "^0.7.2",
     "dotenv": "^6.0.0",
     "iconv-lite": "^0.4.24",


### PR DESCRIPTION
this fix the error:
```log
> node-jq@1.3.1 postinstall /root/bitd/node_modules/node-jq
> npm run install-binary


> node-jq@1.3.1 install-binary /root/bitd/node_modules/node-jq
> node scripts/install-binary.js

jq installed successfully on /root/bitd/node_modules/node-jq/bin

> bigjq@0.0.7 postinstall /root/bitd/node_modules/bigjq
> ./run.sh

npm WARN bigjq@0.0.7 No description
npm WARN bigjq@0.0.7 No repository field.

npm ERR! path /root/bitd/node_modules/bigjq/node_modules/node-jq/bin/jq
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/root/bitd/node_modules/bigjq/node_modules/node-jq/bin/jq'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-04-28T01_45_28_180Z-debug.log
npm WARN bitd@0.2.1 No repository field.

npm ERR! code ELIFECYCLE
npm ERR! errno 254
npm ERR! bigjq@0.0.7 postinstall: `./run.sh`
npm ERR! Exit status 254
npm ERR!
npm ERR! Failed at the bigjq@0.0.7 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-04-28T01_45_29_619Z-debug.log
```